### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,9 +10,9 @@ open-aea-cosmpy = "==0.6.7"
 open-aea-ledger-cosmos = "==1.50.0"
 open-aea-ledger-ethereum = "==1.50.0"
 open-aea-ledger-ethereum-hwi = "==1.50.0"
-open-aea-test-autonomy = "==0.14.9"
+open-aea-test-autonomy = "==0.14.10"
 web3 = "<7,>=6.0.0"
-open-autonomy = {version = "==0.14.9", extras = ["all"]}
+open-autonomy = {version = "==0.14.10", extras = ["all"]}
 
 [dev-packages]
 aiohttp = "<3.8,>=3.7.4"

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {
-        "skill/valory/hello_world_abci/0.1.0": "bafybeiagjdjp5ut4svjyitsrkr4l7gosfefx5ebphrlkaa6a765fwuljai",
-        "agent/valory/hello_world/0.1.0": "bafybeictwjngvb7qon4qisl3q4ztfzvj5pi26zhmpm2oqg6xx6vbz6jrya",
-        "service/valory/hello_world/0.1.0": "bafybeibp2iiojzyykcbkadqdszd35laq2ub34eovyghrsr33t2vrxmk2r4"
+        "skill/valory/hello_world_abci/0.1.0": "bafybeiewgyexdwrfqiqk5lrwvvealed3wc2mkuc6cxqvf2ze44fq46e2xm",
+        "agent/valory/hello_world/0.1.0": "bafybeicsyetd7ekxmknu5fxm3oy44ism5v57dkrhnsvicg625jra5uf5ru",
+        "service/valory/hello_world/0.1.0": "bafybeihaxcuwgywsneagyidpzbrvw3zmsxhgfjtthogh2xijjusueb72sm"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
@@ -13,13 +13,13 @@
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
         "protocol/valory/ledger_api/1.0.0": "bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeidrbrx5np67xc2rm5jvugplopeobawwqongp6meahhzzpzqsgolsu",
-        "connection/valory/abci/0.1.0": "bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra",
+        "contract/valory/service_registry/0.1.0": "bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm",
+        "connection/valory/abci/0.1.0": "bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze",
         "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
         "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
         "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "skill/valory/abstract_abci/0.1.0": "bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4"
+        "skill/valory/abstract_abci/0.1.0": "bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i"
     }
 }

--- a/packages/valory/agents/hello_world/aea-config.yaml
+++ b/packages/valory/agents/hello_world/aea-config.yaml
@@ -11,7 +11,7 @@ fingerprint:
   tests/test_hello_world.py: bafybeifbgqpywtwhk6n4wngdrrk3oujwqw3fsbk54gsw5sep3pkkgym2ue
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra
+- valory/abci:0.1.0:bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze
 - valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
 - valory/ipfs:0.1.0:bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii
 - valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
@@ -23,9 +23,9 @@ protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- valory/abstract_abci:0.1.0:bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
-- valory/hello_world_abci:0.1.0:bafybeiagjdjp5ut4svjyitsrkr4l7gosfefx5ebphrlkaa6a765fwuljai
+- valory/abstract_abci:0.1.0:bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/hello_world_abci:0.1.0:bafybeiewgyexdwrfqiqk5lrwvvealed3wc2mkuc6cxqvf2ze44fq46e2xm
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -58,7 +58,7 @@ dependencies:
   open-aea-ledger-ethereum:
     version: ==1.50.0
   open-aea-test-autonomy:
-    version: ==0.14.9
+    version: ==0.14.10
 default_connection: null
 ---
 public_id: valory/hello_world_abci:0.1.0

--- a/packages/valory/services/hello_world/service.yaml
+++ b/packages/valory/services/hello_world/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiapubcoersqnsnh3acia5hd7otzt7kjxekr6gkbrlumv6tkajl6jm
 fingerprint_ignore_patterns: []
-agent: valory/hello_world:0.1.0:bafybeictwjngvb7qon4qisl3q4ztfzvj5pi26zhmpm2oqg6xx6vbz6jrya
+agent: valory/hello_world:0.1.0:bafybeicsyetd7ekxmknu5fxm3oy44ism5v57dkrhnsvicg625jra5uf5ru
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/hello_world_abci/skill.yaml
+++ b/packages/valory/skills/hello_world_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
 behaviours:
   main:
     args: {}

--- a/setup.py
+++ b/setup.py
@@ -23,3 +23,4 @@ from setuptools import find_packages, setup
 
 if __name__ == "__main__":
     setup(packages=[])
+

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ deps =
     open-aea-cli-ipfs==1.50.0
     open-aea-ledger-ethereum==1.50.0
     open-aea-ledger-ethereum-hwi==1.50.0
-    open-autonomy==0.14.9
-    open-aea-test-autonomy==0.14.9
+    open-autonomy==0.14.10
+    open-aea-test-autonomy==0.14.10
     web3<7,>=6.0.0
     open-aea-ledger-cosmos==1.50.0
     open-aea-cosmpy==0.6.7


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.50.0
- Bumps open-aea-ledger-ethereum to ==1.50.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.50.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.50.0
- Bumps open-aea-ledger-cosmos to ==1.50.0
- Bumps open-aea-ledger-solana to ==1.50.0
- Bumps open-aea-cli-ipfs to ==1.50.0
- Bumps open-autonomy to ==0.14.10
- Bumps open-aea-test-autonomy to ==0.14.10