### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-open-aea = {version = "==1.50.0", extras = ["all"]}
-open-aea-cli-ipfs = "==1.50.0"
+open-aea = {version = "==1.51.0", extras = ["all"]}
+open-aea-cli-ipfs = "==1.51.0"
 open-aea-cosmpy = "==0.6.7"
-open-aea-ledger-cosmos = "==1.50.0"
-open-aea-ledger-ethereum = "==1.50.0"
-open-aea-ledger-ethereum-hwi = "==1.50.0"
-open-aea-test-autonomy = "==0.14.9"
+open-aea-ledger-cosmos = "==1.51.0"
+open-aea-ledger-ethereum = "==1.51.0"
+open-aea-ledger-ethereum-hwi = "==1.51.0"
+open-aea-test-autonomy = "==0.14.11.post1"
 web3 = "<7,>=6.0.0"
-open-autonomy = {version = "==0.14.9", extras = ["all"]}
+open-autonomy = {version = "==0.14.11.post1", extras = ["all"]}
 
 [dev-packages]
 aiohttp = "<3.8,>=3.7.4"

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {
-        "skill/valory/hello_world_abci/0.1.0": "bafybeiagjdjp5ut4svjyitsrkr4l7gosfefx5ebphrlkaa6a765fwuljai",
-        "agent/valory/hello_world/0.1.0": "bafybeictwjngvb7qon4qisl3q4ztfzvj5pi26zhmpm2oqg6xx6vbz6jrya",
-        "service/valory/hello_world/0.1.0": "bafybeibp2iiojzyykcbkadqdszd35laq2ub34eovyghrsr33t2vrxmk2r4"
+        "skill/valory/hello_world_abci/0.1.0": "bafybeih5wrfc5nz7nuom6tvyts4yfixynryapjyt4gr6pot44hhdyc5nea",
+        "agent/valory/hello_world/0.1.0": "bafybeicppfbco6th6n4qwlgcfm7c44dwf4cp3637csqoztlni5swolvprm",
+        "service/valory/hello_world/0.1.0": "bafybeicshpfhhkffaqmo2wddct6qfxytolk5gmwkx5vjqkohlzlkrh6lla"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
@@ -13,13 +13,13 @@
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
         "protocol/valory/ledger_api/1.0.0": "bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeidrbrx5np67xc2rm5jvugplopeobawwqongp6meahhzzpzqsgolsu",
-        "connection/valory/abci/0.1.0": "bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra",
-        "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
-        "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
-        "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
+        "contract/valory/service_registry/0.1.0": "bafybeigrfupd7lo6aet376rwluqgm33jfghibkbvumfsdgrymqxoopqydq",
+        "connection/valory/abci/0.1.0": "bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa",
+        "connection/valory/http_client/0.23.0": "bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u",
+        "connection/valory/ipfs/0.1.0": "bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna",
+        "connection/valory/ledger/0.19.0": "bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "skill/valory/abstract_abci/0.1.0": "bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4"
+        "skill/valory/abstract_abci/0.1.0": "bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy"
     }
 }

--- a/packages/valory/agents/hello_world/aea-config.yaml
+++ b/packages/valory/agents/hello_world/aea-config.yaml
@@ -11,10 +11,10 @@ fingerprint:
   tests/test_hello_world.py: bafybeifbgqpywtwhk6n4wngdrrk3oujwqw3fsbk54gsw5sep3pkkgym2ue
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeibg47tqwbeo5jevjbtkljjv2uc2q5luv77vma3zhwqatt5ya2t2ra
-- valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
-- valory/ipfs:0.1.0:bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii
-- valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
+- valory/abci:0.1.0:bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa
+- valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
+- valory/ipfs:0.1.0:bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna
+- valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts: []
 protocols:
@@ -23,9 +23,9 @@ protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- valory/abstract_abci:0.1.0:bafybeigcfsulh6doa6mifuihtfbdf46dtwlvmvtvilzosu6t5myh63rjre
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
-- valory/hello_world_abci:0.1.0:bafybeiagjdjp5ut4svjyitsrkr4l7gosfefx5ebphrlkaa6a765fwuljai
+- valory/abstract_abci:0.1.0:bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym
+- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
+- valory/hello_world_abci:0.1.0:bafybeih5wrfc5nz7nuom6tvyts4yfixynryapjyt4gr6pot44hhdyc5nea
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -56,9 +56,9 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-test-autonomy:
-    version: ==0.14.9
+    version: ==0.14.11.post1
 default_connection: null
 ---
 public_id: valory/hello_world_abci:0.1.0

--- a/packages/valory/services/hello_world/service.yaml
+++ b/packages/valory/services/hello_world/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiapubcoersqnsnh3acia5hd7otzt7kjxekr6gkbrlumv6tkajl6jm
 fingerprint_ignore_patterns: []
-agent: valory/hello_world:0.1.0:bafybeictwjngvb7qon4qisl3q4ztfzvj5pi26zhmpm2oqg6xx6vbz6jrya
+agent: valory/hello_world:0.1.0:bafybeicppfbco6th6n4qwlgcfm7c44dwf4cp3637csqoztlni5swolvprm
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/hello_world_abci/skill.yaml
+++ b/packages/valory/skills/hello_world_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigr33fuqxsw7dwurncs7b4ogqa736k4ojktd3ucluv22setixe2a4
+- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
 behaviours:
   main:
     args: {}

--- a/setup.py
+++ b/setup.py
@@ -23,3 +23,4 @@ from setuptools import find_packages, setup
 
 if __name__ == "__main__":
     setup(packages=[])
+

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,14 @@ skip_missing_interpreters = true
 [deps-packages]
 deps =
     tomte[tests]==0.2.15
-    open-aea[all]==1.50.0
-    open-aea-cli-ipfs==1.50.0
-    open-aea-ledger-ethereum==1.50.0
-    open-aea-ledger-ethereum-hwi==1.50.0
-    open-autonomy==0.14.9
-    open-aea-test-autonomy==0.14.9
+    open-aea[all]==1.51.0
+    open-aea-cli-ipfs==1.51.0
+    open-aea-ledger-ethereum==1.51.0
+    open-aea-ledger-ethereum-hwi==1.51.0
+    open-autonomy==0.14.11.post1
+    open-aea-test-autonomy==0.14.11.post1
     web3<7,>=6.0.0
-    open-aea-ledger-cosmos==1.50.0
+    open-aea-ledger-cosmos==1.51.0
     open-aea-cosmpy==0.6.7
     grpcio==1.53.0
     hypothesis==6.21.6
@@ -659,7 +659,7 @@ fetchai-ledger-api: >=0.0.1
 chardet: >=3.0.4
 certifi: >=2019.11.28
 ;TODO: the following are confilctive packages that need to be sorted
-; sub-dep of open-aea-ledger-ethereum-hwi
+; sub-dep of open-aea-ledger-ethereum-hwi==1.51.0
 hidapi: >=0.13.1
 ; shows in pip freesze but not referenced on code
 paramiko: >=3.1.0


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.51.0
- Bumps open-aea-ledger-ethereum to ==1.51.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.51.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.51.0
- Bumps open-aea-ledger-cosmos to ==1.51.0
- Bumps open-aea-ledger-solana to ==1.51.0
- Bumps open-aea-cli-ipfs to ==1.51.0
- Bumps open-autonomy to ==0.14.11.post1
- Bumps open-aea-test-autonomy to ==0.14.11.post1