### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-12, windows-latest ]
         python-version: ["3.10.9"]
 
     timeout-minutes: 18
@@ -175,7 +175,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-latest, macos-12, windows-latest ]
         python-version: [ "3.8", "3.9", "3.10.9", "3.11" ]
 
     timeout-minutes: 90
@@ -230,8 +230,8 @@ jobs:
         run: |
           tox -e packages-py${{ matrix.python-version }}-linux -- -m 'not e2e'
 
-      - if: matrix.os == 'macos-latest'
-        name: Install dependencies (macos-latest)
+      - if: matrix.os == 'macos-12'
+        name: Install dependencies (macos-12)
         run: |
           pip install tomte[tox]==0.2.13
           brew install gcc
@@ -257,8 +257,8 @@ jobs:
           tar -xf tendermint.tar.gz
           sudo mv tendermint /usr/local/bin/tendermint
 
-      - if: matrix.os == 'macos-latest'
-        name: Packages unit tests macos-latest
+      - if: matrix.os == 'macos-12'
+        name: Packages unit tests macos-12
         run: |
           tox -e packages-py${{ matrix.python-version }}-darwin -- -m 'not e2e'
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -68,7 +68,7 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt-get autoremove
         sudo apt-get autoclean
-        pip install tomte[tox,cli]==0.2.13
+        pip install tomte[tox,cli]==0.2.17
         pip install --user --upgrade setuptools
     - name: Check copyright headers
       run: tomte format-copyright --author valory --author fetchai
@@ -106,7 +106,7 @@ jobs:
         sudo apt-get update --fix-missing
         sudo apt-get autoremove
         sudo apt-get autoclean
-        pip install tomte[tox]==0.2.13
+        pip install tomte[tox]==0.2.17
         pip install --user --upgrade setuptools
         # install Protobuf compiler
         wget https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
@@ -197,7 +197,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get autoremove
           sudo apt-get autoclean
-          pip install tomte[tox]==0.2.13
+          pip install tomte[tox]==0.2.17
           pip install --user --upgrade setuptools
 
           # install Protobuf compiler
@@ -233,7 +233,7 @@ jobs:
       - if: matrix.os == 'macos-12'
         name: Install dependencies (macos-12)
         run: |
-          pip install tomte[tox]==0.2.13
+          pip install tomte[tox]==0.2.17
           brew install gcc
           # brew install protobuf
           # brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/72457f0166d5619a83f508f2345b22d0617b5021/Formula/protobuf.rb
@@ -275,7 +275,7 @@ jobs:
           choco install make -y
           # to check make was installed
           make --version
-          pip install tomte[tox]==0.2.13
+          pip install tomte[tox]==0.2.17
           # wget https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-win64.zip
           # unzip protoc-3.19.4-win64.zip -d protoc
           # sudo mv protoc/bin/protoc /usr/local/bin/protoc
@@ -340,7 +340,7 @@ jobs:
           sudo apt-get update --fix-missing
           sudo apt-get autoremove
           sudo apt-get autoclean
-          pip install tomte[tox]==0.2.13
+          pip install tomte[tox]==0.2.17
           pip install --user --upgrade setuptools
 
           # install Protobuf compiler

--- a/Pipfile
+++ b/Pipfile
@@ -44,7 +44,7 @@ pytz = "==2022.2.1"
 requests = "==2.28.1"
 texttable = "==1.6.7"
 toml = "==0.10.2"
-tomte = {version = "==0.2.15", extras = ["tests", "cli"]}
+tomte = {version = "==0.2.17", extras = ["tests", "cli"]}
 typing_extensions = ">=3.10.0.2"
 valory-docker-compose = "==1.29.3"
 

--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ open-autonomy = {version = "==0.14.12", extras = ["all"]}
 aiohttp = "<3.8,>=3.7.4"
 asn1crypto = "<1.5.0,>=1.4.0"
 certifi = "*"
-click = "==8.0.2"
+click = ">=8.1.0,<9"
 docker = "==6.1.2"
 ecdsa = ">=0.15"
 eth-abi = "==4.0.0"

--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-open-aea = {version = "==1.51.0", extras = ["all"]}
-open-aea-cli-ipfs = "==1.51.0"
+open-aea = {version = "==1.52.0", extras = ["all"]}
+open-aea-cli-ipfs = "==1.52.0"
 open-aea-cosmpy = "==0.6.7"
-open-aea-ledger-cosmos = "==1.51.0"
-open-aea-ledger-ethereum = "==1.51.0"
-open-aea-ledger-ethereum-hwi = "==1.51.0"
-open-aea-test-autonomy = "==0.14.11.post1"
+open-aea-ledger-cosmos = "==1.52.0"
+open-aea-ledger-ethereum = "==1.52.0"
+open-aea-ledger-ethereum-hwi = "==1.52.0"
+open-aea-test-autonomy = "==0.14.12"
 web3 = "<7,>=6.0.0"
-open-autonomy = {version = "==0.14.11.post1", extras = ["all"]}
+open-autonomy = {version = "==0.14.12", extras = ["all"]}
 
 [dev-packages]
 aiohttp = "<3.8,>=3.7.4"

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {
-        "skill/valory/hello_world_abci/0.1.0": "bafybeih5wrfc5nz7nuom6tvyts4yfixynryapjyt4gr6pot44hhdyc5nea",
-        "agent/valory/hello_world/0.1.0": "bafybeicppfbco6th6n4qwlgcfm7c44dwf4cp3637csqoztlni5swolvprm",
-        "service/valory/hello_world/0.1.0": "bafybeicshpfhhkffaqmo2wddct6qfxytolk5gmwkx5vjqkohlzlkrh6lla"
+        "skill/valory/hello_world_abci/0.1.0": "bafybeihg4hpwizsizlaptffpxqrxdpo4tewg4grp3mtmuzgjp7qzftnpoa",
+        "agent/valory/hello_world/0.1.0": "bafybeiaifgtwm7ptcnkw2alhxj7fvrx75mqsihd7hs6joskvef452a6w7u",
+        "service/valory/hello_world/0.1.0": "bafybeigh2m7udulqoy35qhg75ptnxekw2q2rra4aweqsbh5iilj5lkdgbu"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
@@ -13,13 +13,13 @@
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
         "protocol/valory/ledger_api/1.0.0": "bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeigrfupd7lo6aet376rwluqgm33jfghibkbvumfsdgrymqxoopqydq",
-        "connection/valory/abci/0.1.0": "bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa",
+        "contract/valory/service_registry/0.1.0": "bafybeiekytropd5ysnap2wkekub3byi5jbda3qll7awchvhu5plbpafhmi",
+        "connection/valory/abci/0.1.0": "bafybeicksmavx23ralbdw3ajxv5fq5s4c3wzhbc3zdudefm4jqsgrg72ai",
         "connection/valory/http_client/0.23.0": "bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u",
-        "connection/valory/ipfs/0.1.0": "bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna",
+        "connection/valory/ipfs/0.1.0": "bafybeieaq56usnosbwdslmo6i2yvttwpsm6djvawsowq3jt6bkjwhw3tl4",
         "connection/valory/ledger/0.19.0": "bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "skill/valory/abstract_abci/0.1.0": "bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy"
+        "skill/valory/abstract_abci/0.1.0": "bafybeieh4ei3qdelmacnm7vwq57phoewgumr3udvxt6pybmuggwc3yk65q",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui"
     }
 }

--- a/packages/valory/agents/hello_world/aea-config.yaml
+++ b/packages/valory/agents/hello_world/aea-config.yaml
@@ -11,9 +11,9 @@ fingerprint:
   tests/test_hello_world.py: bafybeifbgqpywtwhk6n4wngdrrk3oujwqw3fsbk54gsw5sep3pkkgym2ue
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeihhtx7t5fsxaoajzq5nm4hrq57smigx7gqv35bss766txaaffjmsa
+- valory/abci:0.1.0:bafybeicksmavx23ralbdw3ajxv5fq5s4c3wzhbc3zdudefm4jqsgrg72ai
 - valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
-- valory/ipfs:0.1.0:bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna
+- valory/ipfs:0.1.0:bafybeieaq56usnosbwdslmo6i2yvttwpsm6djvawsowq3jt6bkjwhw3tl4
 - valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts: []
@@ -23,9 +23,9 @@ protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- valory/abstract_abci:0.1.0:bafybeiedikuvfpdx7xhyrxcpp6ywi2d6qf6uqvlwmhgcal7qhw5duicvym
-- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
-- valory/hello_world_abci:0.1.0:bafybeih5wrfc5nz7nuom6tvyts4yfixynryapjyt4gr6pot44hhdyc5nea
+- valory/abstract_abci:0.1.0:bafybeieh4ei3qdelmacnm7vwq57phoewgumr3udvxt6pybmuggwc3yk65q
+- valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
+- valory/hello_world_abci:0.1.0:bafybeihg4hpwizsizlaptffpxqrxdpo4tewg4grp3mtmuzgjp7qzftnpoa
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -56,9 +56,9 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.51.0
+    version: ==1.52.0
   open-aea-test-autonomy:
-    version: ==0.14.11.post1
+    version: ==0.14.12
 default_connection: null
 ---
 public_id: valory/hello_world_abci:0.1.0

--- a/packages/valory/services/hello_world/service.yaml
+++ b/packages/valory/services/hello_world/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiapubcoersqnsnh3acia5hd7otzt7kjxekr6gkbrlumv6tkajl6jm
 fingerprint_ignore_patterns: []
-agent: valory/hello_world:0.1.0:bafybeicppfbco6th6n4qwlgcfm7c44dwf4cp3637csqoztlni5swolvprm
+agent: valory/hello_world:0.1.0:bafybeiaifgtwm7ptcnkw2alhxj7fvrx75mqsihd7hs6joskvef452a6w7u
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/hello_world_abci/skill.yaml
+++ b/packages/valory/skills/hello_world_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeia7msuvsouwcky263k6lup5hwcj73pka4pepkgyii6sya2wfawqvy
+- valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
 behaviours:
   main:
     args: {}

--- a/setup.py
+++ b/setup.py
@@ -24,3 +24,4 @@ from setuptools import find_packages, setup
 if __name__ == "__main__":
     setup(packages=[])
 
+

--- a/tox.ini
+++ b/tox.ini
@@ -335,7 +335,7 @@ skip_install = True
 deps =
     tomte[safety]==0.2.17
 commands =
-    safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499
+    safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499 -i 67599
 
 [testenv:vulture]
 skipsdist = True

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ skip_missing_interpreters = true
 
 [deps-packages]
 deps =
-    tomte[tests]==0.2.15
+    tomte[tests]==0.2.17
     open-aea[all]==1.52.0
     open-aea-cli-ipfs==1.52.0
     open-aea-ledger-ethereum==1.52.0
@@ -160,7 +160,7 @@ commands = {[commands-packages]commands}
 skipsdist = True
 skip_install = True
 deps =
-    tomte[bandit]==0.2.15
+    tomte[bandit]==0.2.17
 commands =
     bandit -s B101 -r packages/valory
     bandit -s B101 -r scripts
@@ -169,7 +169,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.2.15
+    tomte[black]==0.2.17
 commands =
     black packages/valory scripts
 
@@ -177,7 +177,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[black]==0.2.15
+    tomte[black]==0.2.17
 commands =
     black --check packages/valory scripts
 
@@ -185,7 +185,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.2.15
+    tomte[isort]==0.2.17
 commands =
     isort packages/valory --gitignore
     isort scripts/
@@ -194,7 +194,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[isort]==0.2.15
+    tomte[isort]==0.2.17
 commands =
     isort --check-only --gitignore packages/valory scripts
 
@@ -254,7 +254,7 @@ skipsdist = True
 skip_install = True
 deps =
     {[deps-packages]deps}
-    tomte[docs]==0.2.15
+    tomte[docs]==0.2.17
 commands =
     {toxinidir}/scripts/generate_api_documentation.py --check-clean
 
@@ -263,7 +263,7 @@ skipsdist = True
 skip_install = True
 deps =
     {[deps-packages]deps}
-    tomte[docs]==0.2.15
+    tomte[docs]==0.2.17
 commands =
     {toxinidir}/scripts/generate_api_documentation.py
 
@@ -288,7 +288,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[docs]==0.2.15
+    tomte[docs]==0.2.17
     mkdocs-redirects
 commands =
     mkdocs build --clean --strict
@@ -297,7 +297,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[docs]==0.2.15
+    tomte[docs]==0.2.17
     mkdocs-redirects
 commands =
     mkdocs build --clean --strict
@@ -308,7 +308,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[flake8]==0.2.15
+    tomte[flake8]==0.2.17
 commands =
     flake8 packages/valory scripts
 
@@ -316,7 +316,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[mypy]==0.2.15
+    tomte[mypy]==0.2.17
 commands =
     mypy packages/valory scripts --disallow-untyped-defs --config-file tox.ini
 
@@ -325,7 +325,7 @@ whitelist_externals = /bin/sh
 skipsdist = True
 deps =
     {[deps-packages]deps}
-    tomte[pylint]==0.2.15
+    tomte[pylint]==0.2.17
 commands =
     pylint --rcfile=.pylintrc packages/valory/skills/hello_world_abci scripts -j 0
 
@@ -333,7 +333,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[safety]==0.2.15
+    tomte[safety]==0.2.17
 commands =
     safety check -i 37524 -i 38038 -i 37776 -i 38039 -i 39621 -i 40291 -i 39706 -i 41002 -i 51358 -i 51499
 
@@ -341,7 +341,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[vulture]==0.2.15
+    tomte[vulture]==0.2.17
 commands =
     vulture packages/valory/skills/hello_world_abci scripts/whitelist.py
 
@@ -349,7 +349,7 @@ commands =
 skipsdist = True
 skip_install = True
 deps =
-    tomte[darglint]==0.2.15
+    tomte[darglint]==0.2.17
 commands =
     darglint scripts packages/valory/*
 
@@ -357,7 +357,7 @@ commands =
 whitelist_externals = mdspell
 skipsdist = True
 usedevelop = True
-deps = tomte[cli]==0.2.13
+deps = tomte[cli]==0.2.17
 commands = tomte check-spelling
 
 [testenv:abci-docstrings]
@@ -396,7 +396,7 @@ commands =
 [testenv:liccheck]
 skipsdist = True
 usedevelop = True
-deps = tomte[liccheck,cli]==0.2.13
+deps = tomte[liccheck,cli]==0.2.17
 commands =
     tomte freeze-dependencies --output-path {envtmpdir}/requirements.txt
     liccheck -s tox.ini -r {envtmpdir}/requirements.txt -l PARANOID

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ deps =
     docker==6.1.2
     pytz==2022.2.1
     py-ecc==6.0.0
+    requests>=2.28.1,<2.31.2
+
 
 [deps-base]
 deps ={[deps-packages]deps}

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,14 @@ skip_missing_interpreters = true
 [deps-packages]
 deps =
     tomte[tests]==0.2.15
-    open-aea[all]==1.51.0
-    open-aea-cli-ipfs==1.51.0
-    open-aea-ledger-ethereum==1.51.0
-    open-aea-ledger-ethereum-hwi==1.51.0
-    open-autonomy==0.14.11.post1
-    open-aea-test-autonomy==0.14.11.post1
+    open-aea[all]==1.52.0
+    open-aea-cli-ipfs==1.52.0
+    open-aea-ledger-ethereum==1.52.0
+    open-aea-ledger-ethereum-hwi==1.52.0
+    open-autonomy==0.14.12
+    open-aea-test-autonomy==0.14.12
     web3<7,>=6.0.0
-    open-aea-ledger-cosmos==1.51.0
+    open-aea-ledger-cosmos==1.52.0
     open-aea-cosmpy==0.6.7
     grpcio==1.53.0
     hypothesis==6.21.6
@@ -659,7 +659,7 @@ fetchai-ledger-api: >=0.0.1
 chardet: >=3.0.4
 certifi: >=2019.11.28
 ;TODO: the following are confilctive packages that need to be sorted
-; sub-dep of open-aea-ledger-ethereum-hwi==1.51.0
+; sub-dep of open-aea-ledger-ethereum-hwi==1.52.0
 hidapi: >=0.13.1
 ; shows in pip freesze but not referenced on code
 paramiko: >=3.1.0


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.52.0
- Bumps open-aea-ledger-ethereum to ==1.52.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.52.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.52.0
- Bumps open-aea-ledger-cosmos to ==1.52.0
- Bumps open-aea-ledger-solana to ==1.52.0
- Bumps open-aea-cli-ipfs to ==1.52.0
- Bumps open-autonomy to ==0.14.12
- Bumps open-aea-test-autonomy to ==0.14.12