### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,15 +4,15 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-open-aea = {version = "==1.52.0", extras = ["all"]}
-open-aea-cli-ipfs = "==1.52.0"
+open-aea = {version = "==1.53.0", extras = ["all"]}
+open-aea-cli-ipfs = "==1.53.0"
 open-aea-cosmpy = "==0.6.7"
-open-aea-ledger-cosmos = "==1.52.0"
-open-aea-ledger-ethereum = "==1.52.0"
-open-aea-ledger-ethereum-hwi = "==1.52.0"
-open-aea-test-autonomy = "==0.14.12"
+open-aea-ledger-cosmos = "==1.53.0"
+open-aea-ledger-ethereum = "==1.53.0"
+open-aea-ledger-ethereum-hwi = "==1.53.0"
+open-aea-test-autonomy = "==0.14.13"
 web3 = "<7,>=6.0.0"
-open-autonomy = {version = "==0.14.12", extras = ["all"]}
+open-autonomy = {version = "==0.14.13", extras = ["all"]}
 requests = ">=2.28.1,<2.31.2"
 
 [dev-packages]

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,8 +1,8 @@
 {
     "dev": {
-        "skill/valory/hello_world_abci/0.1.0": "bafybeihg4hpwizsizlaptffpxqrxdpo4tewg4grp3mtmuzgjp7qzftnpoa",
-        "agent/valory/hello_world/0.1.0": "bafybeiaifgtwm7ptcnkw2alhxj7fvrx75mqsihd7hs6joskvef452a6w7u",
-        "service/valory/hello_world/0.1.0": "bafybeigh2m7udulqoy35qhg75ptnxekw2q2rra4aweqsbh5iilj5lkdgbu"
+        "skill/valory/hello_world_abci/0.1.0": "bafybeiaq5zthsuj376eu52fxwbhhsuz7zztaae3rktxwybq272jvksqz2m",
+        "agent/valory/hello_world/0.1.0": "bafybeia2smnkj7jbjkrmuyvf3k47mhic32uhbfruey74n4eux6746xjlga",
+        "service/valory/hello_world/0.1.0": "bafybeicvyhods7idnhvdkrqy7xixambiwynj2i7it5dsam5kli7k6crxdq"
     },
     "third_party": {
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
@@ -13,13 +13,13 @@
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
         "protocol/valory/ledger_api/1.0.0": "bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
-        "contract/valory/service_registry/0.1.0": "bafybeiekytropd5ysnap2wkekub3byi5jbda3qll7awchvhu5plbpafhmi",
-        "connection/valory/abci/0.1.0": "bafybeicksmavx23ralbdw3ajxv5fq5s4c3wzhbc3zdudefm4jqsgrg72ai",
+        "contract/valory/service_registry/0.1.0": "bafybeia3s4p7b2la7ijrej657fqq3x2lkf3b7dwehl5mbljqzbzzp5jnta",
+        "connection/valory/abci/0.1.0": "bafybeig3x4xypkuhcdcd7d4z5tixhowtrsp2ktdm47z75ul4r36ojcqb64",
         "connection/valory/http_client/0.23.0": "bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u",
-        "connection/valory/ipfs/0.1.0": "bafybeieaq56usnosbwdslmo6i2yvttwpsm6djvawsowq3jt6bkjwhw3tl4",
+        "connection/valory/ipfs/0.1.0": "bafybeihf2sojt6yod2oyr4w7zokn42cobgdpxg2egoshlflwpzxkowaeem",
         "connection/valory/ledger/0.19.0": "bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
-        "skill/valory/abstract_abci/0.1.0": "bafybeieh4ei3qdelmacnm7vwq57phoewgumr3udvxt6pybmuggwc3yk65q",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui"
+        "skill/valory/abstract_abci/0.1.0": "bafybeif4uvml6c3ypq6sk3udgzssyjnxepojdcu4igmwqmo6bdvave5l5i",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeihnb4dd2ey2vjhlbprtxhnpc4q4resnsdrhpavjqnqaq467d6ouey"
     }
 }

--- a/packages/valory/agents/hello_world/aea-config.yaml
+++ b/packages/valory/agents/hello_world/aea-config.yaml
@@ -11,9 +11,9 @@ fingerprint:
   tests/test_hello_world.py: bafybeifbgqpywtwhk6n4wngdrrk3oujwqw3fsbk54gsw5sep3pkkgym2ue
 fingerprint_ignore_patterns: []
 connections:
-- valory/abci:0.1.0:bafybeicksmavx23ralbdw3ajxv5fq5s4c3wzhbc3zdudefm4jqsgrg72ai
+- valory/abci:0.1.0:bafybeig3x4xypkuhcdcd7d4z5tixhowtrsp2ktdm47z75ul4r36ojcqb64
 - valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
-- valory/ipfs:0.1.0:bafybeieaq56usnosbwdslmo6i2yvttwpsm6djvawsowq3jt6bkjwhw3tl4
+- valory/ipfs:0.1.0:bafybeihf2sojt6yod2oyr4w7zokn42cobgdpxg2egoshlflwpzxkowaeem
 - valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts: []
@@ -23,9 +23,9 @@ protocols:
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 - valory/ipfs:0.1.0:bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm
 skills:
-- valory/abstract_abci:0.1.0:bafybeieh4ei3qdelmacnm7vwq57phoewgumr3udvxt6pybmuggwc3yk65q
-- valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
-- valory/hello_world_abci:0.1.0:bafybeihg4hpwizsizlaptffpxqrxdpo4tewg4grp3mtmuzgjp7qzftnpoa
+- valory/abstract_abci:0.1.0:bafybeif4uvml6c3ypq6sk3udgzssyjnxepojdcu4igmwqmo6bdvave5l5i
+- valory/abstract_round_abci:0.1.0:bafybeihnb4dd2ey2vjhlbprtxhnpc4q4resnsdrhpavjqnqaq467d6ouey
+- valory/hello_world_abci:0.1.0:bafybeiaq5zthsuj376eu52fxwbhhsuz7zztaae3rktxwybq272jvksqz2m
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -56,9 +56,9 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.52.0
+    version: ==1.53.0
   open-aea-test-autonomy:
-    version: ==0.14.12
+    version: ==0.14.13
 default_connection: null
 ---
 public_id: valory/hello_world_abci:0.1.0

--- a/packages/valory/services/hello_world/service.yaml
+++ b/packages/valory/services/hello_world/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeiapubcoersqnsnh3acia5hd7otzt7kjxekr6gkbrlumv6tkajl6jm
 fingerprint_ignore_patterns: []
-agent: valory/hello_world:0.1.0:bafybeiaifgtwm7ptcnkw2alhxj7fvrx75mqsihd7hs6joskvef452a6w7u
+agent: valory/hello_world:0.1.0:bafybeia2smnkj7jbjkrmuyvf3k47mhic32uhbfruey74n4eux6746xjlga
 number_of_agents: 4
 deployment: {}
 ---

--- a/packages/valory/skills/hello_world_abci/skill.yaml
+++ b/packages/valory/skills/hello_world_abci/skill.yaml
@@ -27,7 +27,7 @@ connections: []
 contracts: []
 protocols: []
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeiar2yhzxacfe3qqamqhaihtlcimquwedffctw55sowx6rac3cm3ui
+- valory/abstract_round_abci:0.1.0:bafybeihnb4dd2ey2vjhlbprtxhnpc4q4resnsdrhpavjqnqaq467d6ouey
 behaviours:
   main:
     args: {}

--- a/setup.py
+++ b/setup.py
@@ -25,3 +25,4 @@ if __name__ == "__main__":
     setup(packages=[])
 
 
+

--- a/tox.ini
+++ b/tox.ini
@@ -15,14 +15,14 @@ skip_missing_interpreters = true
 [deps-packages]
 deps =
     tomte[tests]==0.2.17
-    open-aea[all]==1.52.0
-    open-aea-cli-ipfs==1.52.0
-    open-aea-ledger-ethereum==1.52.0
-    open-aea-ledger-ethereum-hwi==1.52.0
-    open-autonomy==0.14.12
-    open-aea-test-autonomy==0.14.12
+    open-aea[all]==1.53.0
+    open-aea-cli-ipfs==1.53.0
+    open-aea-ledger-ethereum==1.53.0
+    open-aea-ledger-ethereum-hwi==1.53.0
+    open-autonomy==0.14.13
+    open-aea-test-autonomy==0.14.13
     web3<7,>=6.0.0
-    open-aea-ledger-cosmos==1.52.0
+    open-aea-ledger-cosmos==1.53.0
     open-aea-cosmpy==0.6.7
     grpcio==1.53.0
     hypothesis==6.21.6
@@ -661,7 +661,7 @@ fetchai-ledger-api: >=0.0.1
 chardet: >=3.0.4
 certifi: >=2019.11.28
 ;TODO: the following are confilctive packages that need to be sorted
-; sub-dep of open-aea-ledger-ethereum-hwi==1.52.0
+; sub-dep of open-aea-ledger-ethereum-hwi==1.53.0
 hidapi: >=0.13.1
 ; shows in pip freesze but not referenced on code
 paramiko: >=3.1.0


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.53.0
- Bumps open-aea-ledger-ethereum to ==1.53.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.53.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.53.0
- Bumps open-aea-ledger-cosmos to ==1.53.0
- Bumps open-aea-ledger-solana to ==1.53.0
- Bumps open-aea-cli-ipfs to ==1.53.0
- Bumps open-autonomy to ==0.14.13
- Bumps open-aea-test-autonomy to ==0.14.13