### PR TITLE
ci: add aggregate "All checks passed" status gate

### DIFF
--- a/.github/workflows/common_checks.yml
+++ b/.github/workflows/common_checks.yml
@@ -376,3 +376,24 @@ jobs:
       - name: Unit tests
         run: |
           tox --develop -e e2e-py${{ matrix.python-version }}-linux -- -m 'e2e'
+
+  all-checks-passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_doc_and_dependencies_check
+      - linter_checks
+      - scan
+      - test
+      - e2e
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Verify all required jobs succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled"
+            printf 'Job results:\n%s\n' '${{ toJSON(needs) }}'
+            exit 1
+          fi
+          echo "All required jobs passed"


### PR DESCRIPTION
## Summary

- Adds a single meta job `all-checks-passed` (display name: **All checks passed**) to `common_checks.yml` that depends on every mandatory job (`lock_check`, `copyright_doc_and_dependencies_check`, `linter_checks`, `scan`, `test`, `e2e`).
- Uses `if: always()` so it runs even when a dependency fails, and exits 1 if any dependency's `result` is `failure` or `cancelled`.

Purpose: make this the **only** required status check in branch protection. Adding/removing a mandatory CI job in the future only requires editing this job's `needs` list — branch protection settings stay untouched.

## Test plan

- [ ] CI runs green on this PR (including the new `All checks passed` job)
- [ ] After merge, branch protection on `main` is updated to require `All checks passed` (strict, up-to-date branches)